### PR TITLE
Increase statusbar padding to 10dp

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -17,10 +17,10 @@
 -->
 <resources>
     <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">2dp</dimen>
+    <dimen name="status_bar_padding_start">10dp</dimen>
 
     <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">2dp</dimen>
+    <dimen name="status_bar_padding_end">10dp</dimen>
 
     <!-- the padding on the top of the statusbar (usually 0) -->
     <dimen name="status_bar_padding_top">10dp</dimen>


### PR DESCRIPTION
Increase statusbar padding to 10dp to fix icons corssing display border